### PR TITLE
workflow: use 8 jobs on PR, 1 on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      max-parallel: ${{ github.event_name == 'pull_request' && 8 || 1 }}
       matrix:
         version:
           - '25/alpine'


### PR DESCRIPTION
When pushing to main, build in series so that later versions appear higher up on docker hub.

When building pull requests, do 'em all at once!