### PR TITLE
ci: only push images on workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
 name: build
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
   pull_request:
 
 jobs:


### PR DESCRIPTION
We don't need new images built and pushed on every commit to master, only do so when triggered manually.