### PR TITLE
nightly: add debian nightly build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,10 +6,18 @@ on:
   push:
     paths:
       - 'master/Dockerfile'
+      - 'master/alpine/Dockerfile'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - type: ""
+            suffix: ""
+          - type: "-alpine"
+            suffix: "/alpine"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,7 +41,7 @@ jobs:
           echo "docker_platforms=${PLATFORMS}" | tee -a $GITHUB_OUTPUT
           echo "docker_username=bitcoin" | tee -a $GITHUB_OUTPUT
           echo "push=${PUSH}" | tee -a $GITHUB_OUTPUT
-          echo "tags=${REPO}:${BRANCH}" | tee -a $GITHUB_OUTPUT
+          echo "tags=${REPO}:nightly${{ matrix.type }}" | tee -a $GITHUB_OUTPUT
 
       - name: Login into Docker Hub
         uses: docker/login-action@v3
@@ -55,18 +63,10 @@ jobs:
           echo "Push: ${{ steps.prepare.outputs.push }}"
           echo "Tags: ${{ steps.prepare.outputs.tags }}"
 
-          echo docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
-            --output "type=image,push=true" \
-            --progress=plain \
-            --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
-            --build-arg "VCS_REF=${GITHUB_SHA::8}" \
-            $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
-            master/
-
           docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
             --output "type=image,push=${{ steps.prepare.outputs.push }}" \
             --progress=plain \
             --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
             --build-arg "VCS_REF=${GITHUB_SHA::8}" \
             $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
-            master/
+            master${{ matrix.suffix }}

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ These images are built with support for the following platforms:
 
 | Image                              | Platforms                              |
 |------------------------------------|----------------------------------------|
+| `bitcoin/bitcoin:latest`           | linux/amd64, linux/arm64, linux/arm/v7 |
+| `bitcoin/bitcoin:alpine`           | linux/amd64                            |
 | `bitcoin/bitcoin:<version>`        | linux/amd64, linux/arm64, linux/arm/v7 |
 | `bitcoin/bitcoin:<version>-alpine` | linux/amd64                            |
-| `bitcoin/bitcoin:master`           | linux/amd64                            |
+| `bitcoin/bitcoin:nightly`          | linux/amd64, linux/arm64               |
+| `bitcoin/bitcoin:nightly-alpine`   | linux/amd64, linux/arm64               |
 
 The Debian-based (non-alpine) images use pre-built binaries pulled from bitcoincore.org or bitcoin.org (or both) as availability dictates. These binaries are built using the Bitcoin Core [reproducible build](https://github.com/bitcoin/bitcoin/blob/master/contrib/guix/README.md) system, and signatures attesting to them can be found in the [guix.sigs](https://github.com/bitcoin-core/guix.sigs) repo. Signatures are checked in the build process for these docker images using the [verify_binaries.py](https://github.com/bitcoin/bitcoin/tree/master/contrib/verify-binaries) script from the bitcoin/bitcoin git repository.
 
@@ -34,25 +37,26 @@ The nightly master image is currently alpine-based, source-built, and targeted a
 > [IMPORTANT]
 > The Alpine Linux distribution, whilst being a resource efficient Linux distribution with security in mind, is not officially supported by the Bitcoin Core team — use at your own risk.
 
-#### Latest version
+#### Latest released version
 
 These tags refer to the latest major version, and the latest minor and patch of this version where applicable.
 
 - `bitcoin/bitcoin:latest`: Release binaries directly from bitcoincore.org. Caution when specifying this tag in production as blindly upgrading Bitcoin Core major versions can introduce new behaviours.
 - `bitcoin/bitcoin:alpine`: Source-built binaries using the Alpine Linux distribution.
 
-#### Specific version
+#### Specific released version
 
 These tags refer to a specific version of Bitcoin Core.
 
 - `bitcoin/bitcoin:<version>`: Release binaries of a specific release directly from bitcoincore.org (e.g. `27.1` or `26`).
 - `bitcoin/bitcoin:<version>-alpine`: Source-built binaries of a specific release of Bitcoin Core (e.g. `27.1` or `26`) using the Alpine Linux distribution.
 
-#### Nightly master
+#### Nightly master build
 
 This tag refers to a nightly build of https://github.com/bitcoin/bitcoin master branch using Alpine Linux.
 
-- `bitcoin/bitcoin:master`: Source-built binaries on Alpine Linux, compiled nightly using master branch pulled from https://github.com/bitcoin/bitcoin.
+- `bitcoin/bitcoin:nightly`: Source-built binaries on Debian Linux, compiled nightly using master branch pulled from https://github.com/bitcoin/bitcoin.
+- `bitcoin/bitcoin:nightly-alpine`: Source-built binaries on Alpine Linux, compiled nightly using master branch pulled from https://github.com/bitcoin/bitcoin.
 
 ## Usage
 

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,59 +1,46 @@
-# Build stage for Bitcoin Core
-FROM alpine:3.20 AS build
+FROM debian:bookworm-slim AS build
 
-RUN apk --no-cache add \
-    boost-dev \
-    build-base \
-    chrpath \
-    cmake \
-    file \
-    gnupg \
-    git \
-    libevent-dev \
-    libressl \
-    libtool \
-    linux-headers \
-    sqlite-dev \
-    zeromq-dev
+LABEL maintainer.0="Will Clark (@willcl-ark)"
+
+RUN apt-get update -y \
+  && apt-get install -y build-essential git ca-certificates cmake pkg-config python3 libevent-dev libboost-dev libsqlite3-dev libzmq3-dev systemtap-sdt-dev --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV BITCOIN_PREFIX=/opt/bitcoin
 WORKDIR /src
 RUN git clone -b "master" --single-branch --depth 1 "https://github.com/bitcoin/bitcoin.git"
 WORKDIR /src/bitcoin
 
-RUN cmake -B build -DBUILD_TESTS=OFF -DBUILD_UTIL=OFF -DBUILD_TX=ON -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_CCACHE=OFF -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" && \
-    cmake --build build -j$(nproc) && \
-    strip build/src/bitcoin-cli build/src/bitcoin-tx build/src/bitcoind && \
-    cmake --install build
+RUN set -ex \
+  && cmake -B build -DBUILD_TESTS=OFF -DBUILD_UTIL=OFF -DBUILD_TX=ON -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_CCACHE=OFF -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
+  && cmake --build build -j$(nproc) \
+  && strip build/src/bitcoin-cli build/src/bitcoin-tx build/src/bitcoind \
+  && cmake --install build
 
-# Copy build artefacts
-FROM alpine:3.20
+# Second stage
+FROM debian:bookworm-slim
 
-ARG UID=100
+ARG UID=101
 ARG GID=101
 
-LABEL maintainer.0="Will Clark (@willcl-ark)"
-
-RUN addgroup --gid ${GID} --system bitcoin && \
-    adduser --uid ${UID} --system bitcoin --ingroup bitcoin
-RUN apk --no-cache add \
-    bash \
-    libevent \
-    libzmq \
-    shadow \
-    sqlite-libs \
-    su-exec
-
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV PATH=/opt/bin:$PATH
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y libevent-dev libboost-dev libsqlite3-dev libzmq3-dev systemtap-sdt-dev --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build /opt/bitcoin /opt
+ENV PATH=/opt/bin:$PATH
+
 COPY docker-entrypoint.sh /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]
-
 EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
 
 ENTRYPOINT ["/entrypoint.sh"]
-
+RUN bitcoind -version | grep "Bitcoin Core version"
 CMD ["bitcoind"]

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -1,0 +1,59 @@
+# Build stage for Bitcoin Core
+FROM alpine:3.20 AS build
+
+RUN apk --no-cache add \
+    boost-dev \
+    build-base \
+    chrpath \
+    cmake \
+    file \
+    gnupg \
+    git \
+    libevent-dev \
+    libressl \
+    libtool \
+    linux-headers \
+    sqlite-dev \
+    zeromq-dev
+
+ENV BITCOIN_PREFIX=/opt/bitcoin
+WORKDIR /src
+RUN git clone -b "master" --single-branch --depth 1 "https://github.com/bitcoin/bitcoin.git"
+WORKDIR /src/bitcoin
+
+RUN cmake -B build -DBUILD_TESTS=OFF -DBUILD_UTIL=OFF -DBUILD_TX=ON -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_CCACHE=OFF -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" && \
+    cmake --build build -j$(nproc) && \
+    strip build/src/bitcoin-cli build/src/bitcoin-tx build/src/bitcoind && \
+    cmake --install build
+
+# Copy build artefacts
+FROM alpine:3.20
+
+ARG UID=100
+ARG GID=101
+
+LABEL maintainer.0="Will Clark (@willcl-ark)"
+
+RUN addgroup --gid ${GID} --system bitcoin && \
+    adduser --uid ${UID} --system bitcoin --ingroup bitcoin
+RUN apk --no-cache add \
+    bash \
+    libevent \
+    libzmq \
+    shadow \
+    sqlite-libs \
+    su-exec
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV PATH=/opt/bin:$PATH
+
+COPY --from=build /opt/bitcoin /opt
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["bitcoind"]

--- a/master/alpine/docker-entrypoint.sh
+++ b/master/alpine/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
@@ -32,7 +32,7 @@ fi
 
 if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
   echo
-  exec gosu bitcoin "$@"
+  exec su-exec bitcoin "$@"
 fi
 
 echo


### PR DESCRIPTION
- Rename `master` tag to `nightly-alpine`
- Add a debian-based `nightly` image
- Make `nightly` and `nightly-alpine` multi-arch