### PR TITLE
ci: reduce memory needed in CI build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
+        platform: [linux/amd64, linux/arm64]
+        variant:
           - type: ""
             suffix: ""
           - type: "-alpine"
@@ -25,11 +26,19 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.platform }}-${{ matrix.variant.type }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.platform }}-${{ matrix.variant.type }}-
 
       - name: Prepare Docker build
         id: prepare
         run: |
-          PLATFORMS="linux/amd64,linux/arm64"
           REPO="bitcoin/bitcoin"
           BRANCH="master"
           PUSH="false"
@@ -38,10 +47,10 @@ jobs:
           fi
 
           echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" | tee -a $GITHUB_OUTPUT
-          echo "docker_platforms=${PLATFORMS}" | tee -a $GITHUB_OUTPUT
+          echo "docker_platforms=${{ matrix.platform }}" | tee -a $GITHUB_OUTPUT
           echo "docker_username=bitcoin" | tee -a $GITHUB_OUTPUT
           echo "push=${PUSH}" | tee -a $GITHUB_OUTPUT
-          echo "tags=${REPO}:nightly${{ matrix.type }}" | tee -a $GITHUB_OUTPUT
+          echo "tags=${REPO}:nightly${{ matrix.variant.type }}" | tee -a $GITHUB_OUTPUT
 
       - name: Login into Docker Hub
         uses: docker/login-action@v3
@@ -66,7 +75,15 @@ jobs:
           docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
             --output "type=image,push=${{ steps.prepare.outputs.push }}" \
             --progress=plain \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache-new,mode=max" \
             --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
             --build-arg "VCS_REF=${GITHUB_SHA::8}" \
             $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
-            master${{ matrix.suffix }}
+            master${{ matrix.variant.suffix }}
+
+          # Temp fix
+          # https://github.com/docker/build-push-action/issues/252
+          # https://github.com/moby/buildkit/issues/1896
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -3,7 +3,21 @@ FROM debian:bookworm-slim AS build
 LABEL maintainer.0="Will Clark (@willcl-ark)"
 
 RUN apt-get update -y \
-  && apt-get install -y build-essential git ca-certificates cmake pkg-config python3 libevent-dev libboost-dev libsqlite3-dev libzmq3-dev systemtap-sdt-dev --no-install-recommends \
+  && apt-get install -y \
+    build-essential \
+    ca-certificates \
+    ccache \
+    clang-16 \
+    cmake \
+    git \
+    libboost-dev \
+    libevent-dev \
+    libsqlite3-dev \
+    libzmq3-dev \
+    pkg-config \
+    python3 \
+    systemtap-sdt-dev \
+    --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -13,7 +27,15 @@ RUN git clone -b "master" --single-branch --depth 1 "https://github.com/bitcoin/
 WORKDIR /src/bitcoin
 
 RUN set -ex \
-  && cmake -B build -DBUILD_TESTS=OFF -DBUILD_UTIL=OFF -DBUILD_TX=ON -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_CCACHE=OFF -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
+  && cmake -B build \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_TX=ON \
+    -DBUILD_UTIL=OFF \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_CXX_COMPILER=clang++-16 \
+    -DCMAKE_C_COMPILER=clang-16 \
+    -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
+    -DWITH_CCACHE=ON \
   && cmake --build build -j$(nproc) \
   && strip build/src/bitcoin-cli build/src/bitcoin-tx build/src/bitcoind \
   && cmake --install build

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for Bitcoin Core
-FROM alpine:3.20 AS build
+FROM alpine:3.21 AS build
 
 RUN apk --no-cache add \
     boost-dev \
@@ -36,7 +36,7 @@ RUN cmake -B build \
     cmake --install build
 
 # Copy build artefacts
-FROM alpine:3.20
+FROM alpine:3.21
 
 ARG UID=100
 ARG GID=101

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -4,6 +4,7 @@ FROM alpine:3.20 AS build
 RUN apk --no-cache add \
     boost-dev \
     build-base \
+    ccache \
     chrpath \
     cmake \
     file \
@@ -21,7 +22,15 @@ WORKDIR /src
 RUN git clone -b "master" --single-branch --depth 1 "https://github.com/bitcoin/bitcoin.git"
 WORKDIR /src/bitcoin
 
-RUN cmake -B build -DBUILD_TESTS=OFF -DBUILD_UTIL=OFF -DBUILD_TX=ON -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_CCACHE=OFF -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" && \
+RUN cmake -B build \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_TX=ON \
+    -DBUILD_UTIL=OFF \
+    -DCMAKE_BUILD_TYPE=MinSizeRel \
+    -DCMAKE_CXX_FLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768" \
+    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g0" \
+    -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
+    -DWITH_CCACHE=ON && \
     cmake --build build -j$(nproc) && \
     strip build/src/bitcoin-cli build/src/bitcoin-tx build/src/bitcoind && \
     cmake --install build

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -6,6 +6,7 @@ RUN apk --no-cache add \
     build-base \
     ccache \
     chrpath \
+    clang18 \
     cmake \
     file \
     gnupg \
@@ -26,9 +27,9 @@ RUN cmake -B build \
     -DBUILD_TESTS=OFF \
     -DBUILD_TX=ON \
     -DBUILD_UTIL=OFF \
-    -DCMAKE_BUILD_TYPE=MinSizeRel \
-    -DCMAKE_CXX_FLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768" \
-    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g0" \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_CXX_COMPILER=clang++-18 \
+    -DCMAKE_C_COMPILER=clang-18 \
     -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
     -DWITH_CCACHE=ON && \
     cmake --build build -j$(nproc) && \


### PR DESCRIPTION
There are daily segfaults during the master build CI job. Reduce the resources needed to compile the binaries to try and avoid OOM on the GitHub actions runners.