### PR TITLE
master: use bitcoin build commit hash in tag

### DIFF
--- a/.github/workflows/alpine-master.yml
+++ b/.github/workflows/alpine-master.yml
@@ -63,9 +63,12 @@ jobs:
           load: true
           tags: ${{ env.TEST_TAG }}
 
-      - name: Test
+      - name: Test and extract Bitcoin commit hash
         run: |
           docker run --rm ${{ env.TEST_TAG }} bitcoind --version
+          BITCOIN_COMMIT=$(docker run --rm ${{ env.TEST_TAG }} cat /opt/bitcoin_commit.hash)
+          echo "BITCOIN_COMMIT=${BITCOIN_COMMIT}" >> $GITHUB_ENV
+          echo "Bitcoin commit used in build: ${BITCOIN_COMMIT}"
 
       - name: Build and push Docker image
         id: build
@@ -80,7 +83,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
-            VCS_REF=${{ github.sha }}
+            VCS_REF=${{ env.BITCOIN_COMMIT }}
           outputs: type=image,push-by-digest=true,name-canonical=true
 
       - name: Export digest

--- a/.github/workflows/debian-master.yml
+++ b/.github/workflows/debian-master.yml
@@ -63,9 +63,12 @@ jobs:
           load: true
           tags: ${{ env.TEST_TAG }}
 
-      - name: Test
+      - name: Test and extract Bitcoin commit hash
         run: |
           docker run --rm ${{ env.TEST_TAG }} bitcoind --version
+          BITCOIN_COMMIT=$(docker run --rm ${{ env.TEST_TAG }} cat /opt/bitcoin_commit.hash)
+          echo "BITCOIN_COMMIT=${BITCOIN_COMMIT}" >> $GITHUB_ENV
+          echo "Bitcoin commit used in build: ${BITCOIN_COMMIT}"
 
       - name: Build and push Docker image
         id: build
@@ -80,7 +83,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
-            VCS_REF=${{ github.sha }}
+            VCS_REF=${{ env.BITCOIN_COMMIT }}
           outputs: type=image,push-by-digest=true,name-canonical=true
 
       - name: Export digest

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -30,7 +30,8 @@ RUN git clone -b "$COMMIT" --single-branch --depth 1 "https://github.com/bitcoin
     cd bitcoin && \
     git fetch origin "$COMMIT" && \
     git checkout "$COMMIT" && \
-    git clean -fdx
+    git clean -fdx && \
+    git rev-parse HEAD > /src/bitcoin_commit.hash
 
 WORKDIR /src/bitcoin
 
@@ -64,6 +65,7 @@ RUN groupadd --gid ${GID} bitcoin \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build /opt/bitcoin /opt
+COPY --from=build /src/bitcoin_commit.hash /opt/bitcoin_commit.hash
 ENV PATH=/opt/bin:$PATH
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -26,7 +26,8 @@ RUN git clone -b "$COMMIT" --single-branch --depth 1 "https://github.com/bitcoin
     cd bitcoin && \
     git fetch origin "$COMMIT" && \
     git checkout "$COMMIT" && \
-    git clean -fdx
+    git clean -fdx && \
+    git rev-parse HEAD > /src/bitcoin_commit.hash
 
 WORKDIR /src/bitcoin
 
@@ -65,6 +66,7 @@ ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bin:$PATH
 
 COPY --from=build /opt/bitcoin /opt
+COPY --from=build /src/bitcoin_commit.hash /opt/bitcoin_commit.hash
 COPY docker-entrypoint.sh /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]


### PR DESCRIPTION
Currently we set the `VCS_REF` in the docker tag to the commit hash *of this repo* at build time. This makes sense for most projects, who have their dockerfiles in-tree. As we build another project (bitcoin/bitcoin) it makes sense to use the hash of bitcoin/bitcoin at build-time.

Therefore, during the build, export the commit hash to `/opt/bitcoin_commit.hash`, which can be extracted and used for tagging during the CI builds.