### PR TITLE
Capnproto fixups

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS build
+FROM debian:trixie-slim AS build
 
 LABEL maintainer.0="Will Clark (@willcl-ark)"
 
@@ -7,7 +7,7 @@ RUN apt-get update -y \
     build-essential \
     ca-certificates \
     ccache \
-    clang-16 \
+    clang-19 \
     cmake \
     git \
     libboost-dev \
@@ -40,8 +40,8 @@ RUN set -ex \
     -DBUILD_TX=ON \
     -DBUILD_UTIL=OFF \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    -DCMAKE_CXX_COMPILER=clang++-16 \
-    -DCMAKE_C_COMPILER=clang-16 \
+    -DCMAKE_CXX_COMPILER=clang++-19 \
+    -DCMAKE_C_COMPILER=clang-19 \
     -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
     -DWITH_CCACHE=ON \
   && cmake --build build -j$(nproc) \
@@ -49,7 +49,7 @@ RUN set -ex \
   && cmake --install build
 
 # Second stage
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG UID=101
 ARG GID=101

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -2,22 +2,23 @@ FROM debian:trixie-slim AS build
 
 LABEL maintainer.0="Will Clark (@willcl-ark)"
 
-RUN apt-get update -y \
-  && apt-get install -y \
+RUN apt-get update --yes \
+  && apt-get install --yes --no-install-recommends \
     build-essential \
     ca-certificates \
+    capnproto \
     ccache \
     clang-19 \
     cmake \
     git \
     libboost-dev \
+    libcapnp-dev \
     libevent-dev \
     libsqlite3-dev \
     libzmq3-dev \
     pkg-config \
     python3 \
     systemtap-sdt-dev \
-    --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -58,8 +59,15 @@ ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 
 RUN groupadd --gid ${GID} bitcoin \
   && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
-  && apt-get update -y \
-  && apt-get install -y gosu libevent-dev libboost-dev libsqlite3-dev libzmq3-dev systemtap-sdt-dev --no-install-recommends \
+  && apt-get update --yes \
+  && apt-get install --yes --no-install-recommends \
+    capnproto \
+    gosu \
+    libboost-dev \
+    libevent-dev \
+    libsqlite3-dev \
+    libzmq3-dev \
+    systemtap-sdt-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:3.21 AS build
 RUN apk --no-cache add \
     boost-dev \
     build-base \
+    capnproto \
+    capnproto-dev \
     ccache \
     chrpath \
     clang18 \
@@ -55,6 +57,7 @@ RUN addgroup --gid ${GID} --system bitcoin && \
     adduser --uid ${UID} --system bitcoin --ingroup bitcoin
 RUN apk --no-cache add \
     bash \
+    capnproto \
     libevent \
     libzmq \
     shadow \


### PR DESCRIPTION
Add capnproto to master images.

Currently the version of capnproto on Debian 12, 0.9.2, does not play well with `mpgen` used by recently-merged multiprocess PR #31802. Bump clang to 19 while we bump Trixie (as it no longer has clang-16).

This is currently being worked on: bitcoin-core/libmultiprocess#194 but in the meantime bump Debian versions to fix.