### PR TITLE
build: enable zmq in all builds

### DIFF
--- a/28.4/alpine/Dockerfile
+++ b/28.4/alpine/Dockerfile
@@ -57,6 +57,7 @@ RUN ./configure \
   --disable-bench \
   --disable-fuzz-binary \
   --disable-ccache \
+  --enable-zmq \
   --with-gui=no \
   --with-utils \
   --without-libs \

--- a/29.3/alpine/Dockerfile
+++ b/29.3/alpine/Dockerfile
@@ -58,7 +58,8 @@ RUN cmake -B build \
     -DCMAKE_CXX_COMPILER=clang++-20 \
     -DCMAKE_C_COMPILER=clang-20 \
     -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
-    -DWITH_CCACHE=ON && \
+    -DWITH_CCACHE=ON \
+    -DWITH_ZMQ=ON && \
     cmake --build build -j$(nproc) && \
     strip build/bin/bitcoin-cli build/bin/bitcoin-tx build/bin/bitcoind && \
     cmake --install build

--- a/30.2/alpine/Dockerfile
+++ b/30.2/alpine/Dockerfile
@@ -60,7 +60,8 @@ RUN cmake -B build \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_COMPILER="clang++-${CLANG_V}" \
     -DCMAKE_C_COMPILER="clang-${CLANG_V}" \
-    -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" && \
+    -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
+    -DWITH_ZMQ=ON && \
     cmake --build build -j$(nproc) && \
     strip build/bin/bitcoin-cli build/bin/bitcoin-tx build/bin/bitcoind build/bin/bitcoin build/bin/bitcoin-node && \
     cmake --install build

--- a/31.0/alpine/Dockerfile
+++ b/31.0/alpine/Dockerfile
@@ -60,7 +60,8 @@ RUN cmake -B build \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_COMPILER="clang++-${CLANG_V}" \
     -DCMAKE_C_COMPILER="clang-${CLANG_V}" \
-    -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" && \
+    -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
+    -DWITH_ZMQ=ON && \
     cmake --build build -j$(nproc) && \
     strip build/bin/bitcoin-cli build/bin/bitcoin-tx build/bin/bitcoind build/bin/bitcoin build/bin/bitcoin-node && \
     cmake --install build

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -45,6 +45,7 @@ RUN set -ex \
     -DCMAKE_C_COMPILER=clang-19 \
     -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
     -DWITH_CCACHE=ON \
+    -DWITH_ZMQ=ON \
   && cmake --build build -j$(nproc) \
   && strip build/bin/bitcoin-cli build/bin/bitcoin-tx build/bin/bitcoind \
   && cmake --install build

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -38,7 +38,8 @@ RUN cmake -B build \
     -DCMAKE_CXX_COMPILER=clang++-21 \
     -DCMAKE_C_COMPILER=clang-21 \
     -DCMAKE_INSTALL_PREFIX:PATH="${BITCOIN_PREFIX}" \
-    -DWITH_CCACHE=ON && \
+    -DWITH_CCACHE=ON \
+    -DWITH_ZMQ=ON && \
     cmake --build build -j$(nproc) && \
     cmake --install build --strip
 


### PR DESCRIPTION
It is enabled in 28.x already, but explicitly pass the flag.

Should close #81.