### PR TITLE
ci: update GH Actions versions

### DIFF
--- a/.github/workflows/alpine-master.yml
+++ b/.github/workflows/alpine-master.yml
@@ -26,10 +26,10 @@ jobs:
             docker: linux/arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Prepare
         run: |
@@ -44,7 +44,7 @@ jobs:
           tags: type=raw,value=${{ env.TAGS }}
 
       - name: Login into Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: bitcoin
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -109,13 +109,13 @@ jobs:
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: bitcoin
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       push: ${{ steps.matrix.outputs.push }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Discover versions and set matrix
         id: matrix
@@ -54,13 +54,13 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Prepare Docker build
         id: prepare
@@ -87,7 +87,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ needs.discover.outputs.push == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: bitcoin
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/debian-master.yml
+++ b/.github/workflows/debian-master.yml
@@ -26,10 +26,10 @@ jobs:
             docker: linux/arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Prepare
         run: |
@@ -44,7 +44,7 @@ jobs:
           tags: type=raw,value=${{ env.TAGS }}
 
       - name: Login into Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: bitcoin
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -109,13 +109,13 @@ jobs:
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: bitcoin
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -10,7 +10,7 @@ jobs:
   dockerHubDescription:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Docker Hub Description
       uses: peter-evans/dockerhub-description@v4


### PR DESCRIPTION
Related to:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: docker/setup-buildx-action@v3, docker/setup-qemu-action@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

https://github.com/willcl-ark/bitcoin-core-docker/actions/runs/25726964665/job/75542131292#step:15:2.