### PR TITLE
ci: disable unnecessary CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - master
     tags:
       - 'v*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,12 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - '*/Dockerfile'
+      - '*/docker-entrypoint.sh'
+      - '*/alpine/Dockerfile'
+      - '*/alpine/docker-entrypoint.sh'
+  push:
     tags:
       - 'v*'
 

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,5 +1,6 @@
 name: Update Docker Hub Description
 on:
+  push:
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,8 +1,5 @@
 name: Update Docker Hub Description
 on:
-  push:
-    branches:
-      - master
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml


### PR DESCRIPTION
Currently when we push to master we (re-run) the build.yml job.

This is a waste, as we just ran in in the PR. Disable it (and description job).

Also disable build.yml runs when a PR does not modify anything build-related.