### PR TITLE
Restrict Docker Hub workflow to master

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,6 +1,8 @@
 name: Update Docker Hub Description
 on:
   push:
+    branches:
+      - master
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml


### PR DESCRIPTION
The Docker Hub description update publishes repository-facing metadata, so feature branch pushes should not run it just because they touch README.md. Keep the existing path filter while requiring the push target to be master.