### PR TITLE
master: drop some runtime deps

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -61,10 +61,10 @@ RUN groupadd --gid ${GID} bitcoin \
   && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update --yes \
   && apt-get install --yes --no-install-recommends \
-    capnproto \
+    libcapnp-1.1.0 \
     gosu \
-    libsqlite3-dev \
-    libzmq3-dev \
+    libsqlite3-0 \
+    libzmq5 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -63,7 +63,6 @@ RUN groupadd --gid ${GID} bitcoin \
   && apt-get install --yes --no-install-recommends \
     capnproto \
     gosu \
-    libboost-dev \
     libsqlite3-dev \
     libzmq3-dev \
     systemtap-sdt-dev \

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -65,7 +65,6 @@ RUN groupadd --gid ${GID} bitcoin \
     gosu \
     libsqlite3-dev \
     libzmq3-dev \
-    systemtap-sdt-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
The runtime container doesn't need anything dev related. It also doesn't need any boost libs.